### PR TITLE
change variable isEditable to getCanEdit function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remirror-extension-note",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A note extension built for remirror rich text editor",
   "author": "Santosh Viswanatham",
   "license": "MIT",

--- a/src/note-component.tsx
+++ b/src/note-component.tsx
@@ -15,7 +15,7 @@ export type NoteComponentProps = NodeViewComponentProps & {
   Loader?: React.ComponentType<{}> | null;
   context?: UploadContext;
   abort: () => void;
-  isEditable?: boolean;
+  getCanEdit?: () => void,
   reportType?: string;
 };
 
@@ -82,7 +82,7 @@ const ConvertToQuoteButton = (props: { position: () => number; id: any; noteUrl:
   )
 }
 
-export const NoteComponent: React.FC<NoteComponentProps> = ({ node, getPosition, isEditable, VariantDropdown }) => {
+export const NoteComponent: React.FC<NoteComponentProps> = ({ node, getPosition, getCanEdit, VariantDropdown }) => {
   const noteDetails = node.attrs as NoteAttributes;
   const { noteUrl = ''} = noteDetails;
   const { deleteFile, updateVariant } = useCommands();
@@ -140,7 +140,7 @@ export const NoteComponent: React.FC<NoteComponentProps> = ({ node, getPosition,
     }, [noteDetails]);
 
   return (
-    <div className={`NOTE_ROOT ${ isEditable ? 'NOTE_EDITABLE' : '' }`}>
+    <div className={`NOTE_ROOT ${ getCanEdit() ? 'NOTE_EDITABLE' : '' }`}>
       <a href={noteUrl} data-print-id="note-link" className="NOTE_LINK" />
       <div className="NOTE_LABELS_CONTAINER">
         {noteDetails.labels && Array.isArray(noteDetails.labels) && noteDetails.labels.map((label: any) => (

--- a/src/note-component.tsx
+++ b/src/note-component.tsx
@@ -15,7 +15,7 @@ export type NoteComponentProps = NodeViewComponentProps & {
   Loader?: React.ComponentType<{}> | null;
   context?: UploadContext;
   abort: () => void;
-  getCanEdit?: () => void,
+  getCanEdit?: () => boolean,
   reportType?: string;
 };
 

--- a/src/note-component.tsx
+++ b/src/note-component.tsx
@@ -15,7 +15,7 @@ export type NoteComponentProps = NodeViewComponentProps & {
   Loader?: React.ComponentType<{}> | null;
   context?: UploadContext;
   abort: () => void;
-  getCanEdit?: () => boolean,
+  getCanEdit?: () => boolean;
   reportType?: string;
 };
 

--- a/src/note-extension.tsx
+++ b/src/note-extension.tsx
@@ -74,7 +74,7 @@ export interface NoteOptions {
     /**
      * Function to check if the note is editable
      */
-    getCanEdit?: () => void;
+    getCanEdit?: () => boolean;
     /**
      * Report type
      */
@@ -91,7 +91,7 @@ export interface NoteOptions {
         Loader: null,
         render: VariantRenderer,
         createNode: false,
-        getCanEdit: () => void,
+        getCanEdit: () => true,
         pasteRuleRegexp: /^((?!image).)*$/i,
         reportType: "",
     },

--- a/src/note-extension.tsx
+++ b/src/note-extension.tsx
@@ -72,9 +72,9 @@ export interface NoteOptions {
         (props: { tr: Transaction; pos: number; node: ProsemirrorNode }) => void
     >;
     /**
-     * Is the note editable
+     * Function to check if the note is editable
      */
-    isEditable?: boolean;
+    getCanEdit?: () => void;
     /**
      * Report type
      */
@@ -91,7 +91,7 @@ export interface NoteOptions {
         Loader: null,
         render: VariantRenderer,
         createNode: false,
-        isEditable: false,
+        getCanEdit: () => void,
         pasteRuleRegexp: /^((?!image).)*$/i,
         reportType: "",
     },
@@ -113,7 +113,7 @@ export class NoteExtension extends NodeExtension<NoteOptions> {
             variantComponents: this.options.variantComponents,
             abort: () => {},
             context: undefined,
-            isEditable: this.options.isEditable,
+            getCanEdit: this.options.getCanEdit,
             reportType: this.options.reportType,
         });
     };
@@ -154,7 +154,7 @@ export class NoteExtension extends NodeExtension<NoteOptions> {
                 key: { default: null },
             },
             selectable: true,
-            draggable: this.options.isEditable,
+            draggable: this.options.getCanEdit(),
             atom: true,
             content: "",
             ...override,


### PR DESCRIPTION
We are replacing the `isEditable` variable to a function `getCanEdit` so that the correct value of **canEdit** can be passed to the note and playlist extensions.